### PR TITLE
Revert "init: aosp: Update the LEDs boot colors"

### DIFF
--- a/init/init_sony/init_board_device.h
+++ b/init/init_sony/init_board_device.h
@@ -35,8 +35,8 @@ public:
         // Short vibration
         vibrate(75);
 
-        // LED boot selection colors
-        led_color(0, 225, 0);
+        // LED purple
+        led_color(255, 0, 255);
     }
 
     // Board: finalization of keycheck
@@ -53,15 +53,15 @@ public:
     // Board: Introduction for Android
     virtual void introduce_android()
     {
-        // Power off LED
+        // LED off
         led_color(0, 0, 0);
     }
 
     // Board: Introduction for Recovery
     virtual void introduce_recovery()
     {
-        // LED Recovery colors
-        led_color(0, 0, 255);
+        // LED orange
+        led_color(255, 100, 0);
     }
 
     // Board: Finish init execution


### PR DESCRIPTION
Purple and Orange have a long history for these functions, changing
them now will confuse users. Also purple and orange are not used
by the bootloader (red=booterror, green=flashmode, blue=fastboot)
so it also serves as an indicator that boot is progressing correctly,
and not mistaken for one of these bootloader modes. This is especially
true for blue, where entering recovery without a backlight will very
easily be mistaken for fastboot.

This reverts commit 0ae2bc4a989898bdbb3ceba47dc04034ffc37bdc.
