### PR TITLE
init: extract_ramdisk: Increase buffer size to 28MB

### DIFF
--- a/extract_ramdisk/extract_ramdisk.cpp
+++ b/extract_ramdisk/extract_ramdisk.cpp
@@ -46,8 +46,8 @@
 #define EER_TMP_RAMDISK_CPIO "ramdisk.cpio" // temporary ramdisk cpio file name
 #define EER_SEARCH_STRING "fota-ua" // String to search to determine if the
                                     // ramdisk is a stock Sony FOTA ramdisk
-#define MEMORY_BUFFER_SIZE (const size_t)20*1024*1024 // Max size of uncompressed
-                                                   // ramdisk (20 MB)
+#define MEMORY_BUFFER_SIZE (const size_t)28*1024*1024 // Max size of uncompressed
+                                                   // ramdisk (28 MB)
 #ifndef PATH_MAX
 #define PATH_MAX 255
 #endif


### PR DESCRIPTION
- Fixes 'gunzip error -- Err:inflate, Failed to gunzip'
  on newer Sony devices with TWRP in the FOTA partition
- A minimum need of 24-25MB was observed on Sony Dora,
  therefore leave a margin of evolution with 28MB

Change-Id: Ie8d759f94ddf1cc2e39601ee6279e8f67decf8ba
