### PR TITLE
init: Remove /cache symlink on recovery boot

### DIFF
--- a/init/init_ramdisk.cpp
+++ b/init/init_ramdisk.cpp
@@ -26,6 +26,7 @@ void ramdisk_clean_files(void)
     unlink("/sbin/healthd");
     unlink("/sbin/ueventd");
     unlink("/sbin/watchdogd");
+    unlink("/cache");
     unlink("/charger");
     unlink("/d");
     unlink("/default.prop");


### PR DESCRIPTION
- On 7.1, /cache is now a symlink to /data/cache,
  and mounting cache fails due to the broken symlink,
  recovery ramdisk will handle the cache its own way

Change-Id: Iffee9fddb1eced60ac1ed06359c0f11a88f4b8d0
