### PR TITLE
init: aosp: Debug the current device configuration on build

### DIFF
--- a/init/Android.mk
+++ b/init/Android.mk
@@ -131,6 +131,9 @@ ifneq ($(fota_num_set),true)
 $(error device-sony-common-init: DEV_BLOCK_FOTA_NUM missing for "$(TARGET_DEVICE)", platform "$(PRODUCT_PLATFORM)")
 endif
 
+# Debug current init_sony settings
+$(info device-sony-common-init: init_sony for "$(TARGET_DEVICE)", platform "$(PRODUCT_PLATFORM)", with $(LOCAL_CFLAGS))
+
 # FOTA check is broken on all devices
 LOCAL_CFLAGS += -DFOTA_RAMDISK_CHECK="0"
 


### PR DESCRIPTION
 * Example: device-sony-common-init: init_sony for "dora",
    platform "tone", with  -DDEV_BLOCK_FOTA_NUM="45"
    -DDEV_BLOCK_FOTA_MAJOR="259" -DDEV_BLOCK_FOTA_MINOR="13"

Change-Id: I0fa2a77a60143877ab05c7c18bb886dd6dfb75a7