### PR TITLE
init: extract_ramdisk: Increase buffer size to 40MB

### DIFF
--- a/extract_ramdisk/extract_ramdisk.cpp
+++ b/extract_ramdisk/extract_ramdisk.cpp
@@ -46,8 +46,8 @@
 #define EER_TMP_RAMDISK_CPIO "ramdisk.cpio" // temporary ramdisk cpio file name
 #define EER_SEARCH_STRING "fota-ua" // String to search to determine if the
                                     // ramdisk is a stock Sony FOTA ramdisk
-#define MEMORY_BUFFER_SIZE (const size_t)28*1024*1024 // Max size of uncompressed
-                                                   // ramdisk (28 MB)
+#define MEMORY_BUFFER_SIZE (const size_t)40*1024*1024 // Max size of uncompressed
+                                                   // ramdisk (40 MB)
 #ifndef PATH_MAX
 #define PATH_MAX 255
 #endif


### PR DESCRIPTION
 * Once again the buffer size is too small for devices
    like the Xperia X Perf. and XZ (dora and kagura),
    therefore increase the buffer up to 40MB

Change-Id: I5010b85073b993c44c53422b852970144fca5e62