### PR TITLE
init: Update init_sony build barrier

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,4 +1,4 @@
-ifneq ($(filter yukon rhine shinano kanuti kitakami loire tone yoshino,$(PRODUCT_PLATFORM)),)
+ifeq ($(BOARD_USES_INIT_SONY),true)
 
 LOCAL_PATH := $(call my-dir)
 


### PR DESCRIPTION
init_sony is a workaround for Sony devices that are not able
to reboot to FOTAKernel by "reboot recovery" command or such.
Since we have already "fixed" such behaviour on loire and tone,
this helper becomes redundant for those platforms and should
not be built by default