### PR TITLE
Implement LZMA ramdisk deflate

### DIFF
--- a/extract_ramdisk/Android.mk
+++ b/extract_ramdisk/Android.mk
@@ -1,7 +1,10 @@
 LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 
-LOCAL_SRC_FILES := extract_ramdisk.cpp main.cpp
+LOCAL_SRC_FILES := uncompress.cpp \
+    extract_ramdisk.cpp \
+    main.cpp
+
 LOCAL_FORCE_STATIC_EXECUTABLE := true
 LOCAL_STATIC_LIBRARIES := libelf libc libm libz
 LOCAL_C_INCLUDES := \

--- a/extract_ramdisk/Android.mk
+++ b/extract_ramdisk/Android.mk
@@ -6,7 +6,12 @@ LOCAL_SRC_FILES := uncompress.cpp \
     main.cpp
 
 LOCAL_FORCE_STATIC_EXECUTABLE := true
-LOCAL_STATIC_LIBRARIES := libelf libc libm libz
+LOCAL_STATIC_LIBRARIES := \
+    libelf \
+    libc \
+    liblzma \
+    libm \
+    libz
 LOCAL_C_INCLUDES := \
 	external/elfutils/libelf \
 	external/zlib

--- a/extract_ramdisk/extract_ramdisk.cpp
+++ b/extract_ramdisk/extract_ramdisk.cpp
@@ -37,8 +37,9 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include "gelf.h"
 #include "bootimg.h"
+#include "gelf.h"
+#include "uncompress.h"
 #include "zlib.h"
 
 #define ELF_RAMDISK_LOCATION 2 // Ramdisk is the second file in the image
@@ -46,13 +47,9 @@
 #define EER_TMP_RAMDISK_CPIO "ramdisk.cpio" // temporary ramdisk cpio file name
 #define EER_SEARCH_STRING "fota-ua" // String to search to determine if the
                                     // ramdisk is a stock Sony FOTA ramdisk
-#define MEMORY_BUFFER_SIZE (const size_t)40*1024*1024 // Max size of uncompressed
-                                                   // ramdisk (40 MB)
 #ifndef PATH_MAX
 #define PATH_MAX 255
 #endif
-
-typedef char* byte_p;
 
 char input_filename[PATH_MAX], output_filename[PATH_MAX], tmp_dir[PATH_MAX];
 int has_input = 0, has_output = 0, dont_unzip = 0, check_ramdisk = 0;
@@ -65,33 +62,6 @@ int path_exists(const char* path) {
 		return 0;
 	else
 		return -1;
-}
-
-size_t uncompress_gzip_memory(const byte_p compressed_data,
-	const size_t compressed_data_size, const byte_p uncompressed_data,
-	const size_t uncompressed_max_size) {
-	z_stream zInfo = {0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-	zInfo.avail_in = compressed_data_size;
-	zInfo.total_in = compressed_data_size;
-	zInfo.avail_out = uncompressed_max_size;
-	zInfo.total_out = uncompressed_max_size;
-	zInfo.next_in = (unsigned char *)compressed_data;
-	zInfo.next_out = (unsigned char *)uncompressed_data;
-	size_t return_value = 0;
-	unsigned long err = inflateInit2(&zInfo, 16 + MAX_WBITS); // zlib function
-
-	if (err == Z_OK) {
-		err = inflate( &zInfo, Z_FINISH); // zlib function
-		if (err == Z_STREAM_END) {
-			return_value = zInfo.total_out;
-		} else {
-			printf("gunzip error -- Err:inflate %lu\n", err);
-		}
-	} else {
-		printf("gunzip error -- Err:inflateInit2 %lu\n", err);
-	}
-	inflateEnd(&zInfo);
-	return(return_value);
 }
 
 int scan_file_for_data(char *filename, unsigned char *data, int data_size,
@@ -193,24 +163,8 @@ int copy_file_part(const char* infile, const char* outfile,
 
 	if (!dont_unzip) {
 		uncompressed_buffer = (byte_p) malloc(MEMORY_BUFFER_SIZE);
-		if (uncompressed_buffer == NULL) {
-			free(buffer);
-			printf("Unable to malloc memory for gunzip.\nFailed\n");
-			return -1;
-		}
-		size_t uncompressed_size;
-		uncompressed_size = uncompress_gzip_memory(buffer, file_size,
-			uncompressed_buffer, MEMORY_BUFFER_SIZE);
-		free(buffer);
-		if (uncompressed_size <= 0) {
-			free(uncompressed_buffer);
-			printf("Failed to gunzip\n");
-			return -1;
-		}
-		printf("Original size: %lu, gunzipped: %zu\n", file_size,
-			uncompressed_size);
+		file_size = (unsigned long) uncompress_memory(uncompressed_buffer, buffer, file_size);
 		buffer = uncompressed_buffer;
-		file_size = uncompressed_size;
 	}
 
 	// Open the output file
@@ -225,8 +179,8 @@ int copy_file_part(const char* infile, const char* outfile,
 	}
 
 	// Copy the file
-	printf("Copying '%s' to '%s'\n", infile, outfile);
 	result = fwrite(buffer, 1, file_size, oFile);
+
 	if (!dont_unzip)
 		free(uncompressed_buffer);
 	else

--- a/extract_ramdisk/uncompress.cpp
+++ b/extract_ramdisk/uncompress.cpp
@@ -44,6 +44,12 @@
 
 #include "uncompress.h"
 
+#define MAX_DEBUG_HEX_OUTPUT 16
+
+// memcmp needs buffer, no way to use preprocessor var
+char gzip_header[] = { 0x1f, 0x8B };
+char lzma_header[] = { 0x5d, 0x00, 0x00, 0x80, 0x00, 0xff };
+
 size_t uncompress_gzip_memory(const byte_p compressed_data,
 	const size_t compressed_data_size, const byte_p uncompressed_data,
 	const size_t uncompressed_max_size) {
@@ -77,18 +83,37 @@ size_t uncompress_memory(byte_p uncompressed_buffer, byte_p buffer, unsigned lon
 		printf("Unable to malloc memory for gunzip.\nFailed\n");
 		return -1;
 	}
-	size_t uncompressed_size;
-	uncompressed_size = uncompress_gzip_memory(buffer, file_size,
-		uncompressed_buffer, MEMORY_BUFFER_SIZE);
+	size_t uncompressed_size = 0;
+
+	if (!memcmp(gzip_header, buffer, sizeof(gzip_header))) {
+		printf("GZIP ramdisk found\n");
+		uncompressed_size = uncompress_gzip_memory(buffer, file_size,
+			uncompressed_buffer, MEMORY_BUFFER_SIZE);
+	} else if (!memcmp(lzma_header, buffer, sizeof(lzma_header))) {
+		printf("LZMA ramdisk found\n");
+		return -255; //Unsupported yet
+	} else {
+		char header[MAX_DEBUG_HEX_OUTPUT];
+		memcpy(header, buffer, sizeof((char*)16));
+		printf("Unrecognized ramdisk compression (");
+		int i=0;
+		for (i=0; i<MAX_DEBUG_HEX_OUTPUT ; i++) {
+			printf(" 0x%x", header[i]);
+		}
+		free(buffer);
+		printf("). Giving up! \n");
+		return -2;
+	}
+
 	free(buffer);
 	if (uncompressed_size <= 0) {
 		free(uncompressed_buffer);
-		printf("Failed to gunzip\n");
-		return -1;
+		printf("Failed to deflate\n");
+		return -2;
 	}
-	printf("Original size: %lu, gunzipped: %zu\n", file_size,
+	printf("Original size: %lu, deflated size: %zu\n", file_size,
 		uncompressed_size);
-	buffer = uncompressed_buffer;
+
 	return(uncompressed_size);
 }
 

--- a/extract_ramdisk/uncompress.cpp
+++ b/extract_ramdisk/uncompress.cpp
@@ -1,0 +1,94 @@
+/*
+ * This binary extracts the ramdisk from a Sony ELF or ANDROID boot or
+ * recovery image, gunzips it, checks to make sure that it is not a
+ * stock recovery ramdisk, and then places it in the destination.
+ * The goal is to use the FOTA partition to store a recovery image
+ * and extract the ramdisk to be used during boot on Sony devices that
+ * typically have a recovery-in-boot setup due to Sony disabling the
+ * ability to boot the FOTA partition on unlocked devices. This binary
+ * allows the recovery ramdisk to be separate from the boot partition
+ * so that users can decide what recovery they want to have instead of
+ * being stuck with whatever recovery their kernel or ROM maker decided
+ * to include in the boot image.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * The code was written from scratch by Dees_Troy dees_troy at
+ * yahoo
+ *
+ * Copyright (c) 2013
+ * Copyright (C) 2016 The CyanogenMod Project
+ * Copyright (C) 2018 The OmniRom Project
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include "gelf.h"
+#include "bootimg.h"
+#include "zlib.h"
+
+#include "uncompress.h"
+
+size_t uncompress_gzip_memory(const byte_p compressed_data,
+	const size_t compressed_data_size, const byte_p uncompressed_data,
+	const size_t uncompressed_max_size) {
+	z_stream zInfo = {0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+	zInfo.avail_in = compressed_data_size;
+	zInfo.total_in = compressed_data_size;
+	zInfo.avail_out = uncompressed_max_size;
+	zInfo.total_out = uncompressed_max_size;
+	zInfo.next_in = (unsigned char *)compressed_data;
+	zInfo.next_out = (unsigned char *)uncompressed_data;
+	size_t return_value = 0;
+	unsigned long err = inflateInit2(&zInfo, 16 + MAX_WBITS); // zlib function
+
+	if (err == Z_OK) {
+		err = inflate( &zInfo, Z_FINISH); // zlib function
+		if (err == Z_STREAM_END) {
+			return_value = zInfo.total_out;
+		} else {
+			printf("gunzip error -- Err:inflate %lu\n", err);
+		}
+	} else {
+		printf("gunzip error -- Err:inflateInit2 %lu\n", err);
+	}
+	inflateEnd(&zInfo);
+	return(return_value);
+}
+
+size_t uncompress_memory(byte_p uncompressed_buffer, byte_p buffer, unsigned long file_size) {
+	if (uncompressed_buffer == NULL) {
+		free(buffer);
+		printf("Unable to malloc memory for gunzip.\nFailed\n");
+		return -1;
+	}
+	size_t uncompressed_size;
+	uncompressed_size = uncompress_gzip_memory(buffer, file_size,
+		uncompressed_buffer, MEMORY_BUFFER_SIZE);
+	free(buffer);
+	if (uncompressed_size <= 0) {
+		free(uncompressed_buffer);
+		printf("Failed to gunzip\n");
+		return -1;
+	}
+	printf("Original size: %lu, gunzipped: %zu\n", file_size,
+		uncompressed_size);
+	buffer = uncompressed_buffer;
+	return(uncompressed_size);
+}
+

--- a/extract_ramdisk/uncompress.h
+++ b/extract_ramdisk/uncompress.h
@@ -1,0 +1,50 @@
+/*
+ * This binary extracts the ramdisk from a Sony ELF or ANDROID boot or
+ * recovery image, gunzips it, checks to make sure that it is not a
+ * stock recovery ramdisk, and then places it in the destination.
+ * The goal is to use the FOTA partition to store a recovery image
+ * and extract the ramdisk to be used during boot on Sony devices that
+ * typically have a recovery-in-boot setup due to Sony disabling the
+ * ability to boot the FOTA partition on unlocked devices. This binary
+ * allows the recovery ramdisk to be separate from the boot partition
+ * so that users can decide what recovery they want to have instead of
+ * being stuck with whatever recovery their kernel or ROM maker decided
+ * to include in the boot image.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ *
+ * The code was written from scratch by Dees_Troy dees_troy at
+ * yahoo
+ *
+ * Copyright (c) 2013
+ * Copyright (C) 2016 The CyanogenMod Project
+ * Copyright (C) 2018 The OmniRom Project
+ */
+
+#ifndef __UNCOMPRESS_H__
+#define __UNCOMPRESS_H__
+
+#define MEMORY_BUFFER_SIZE (const size_t)40*1024*1024 // Max size of uncompressed
+                                                   // ramdisk (40 MB)
+
+typedef char* byte_p;
+
+size_t uncompress_gzip_memory(const byte_p compressed_data,
+		const size_t compressed_data_size, const byte_p uncompressed_data,
+		const size_t uncompressed_max_size);
+
+size_t uncompress_memory(byte_p uncompressed_buffer, byte_p buffer, unsigned long file_size);
+
+#endif // __UNCOMPRESS_H__

--- a/init/Android.mk
+++ b/init/Android.mk
@@ -24,6 +24,7 @@ LOCAL_SRC_FILES := \
     init_io.cpp \
     init_main.cpp \
     init_ramdisk.cpp \
+    ../extract_ramdisk/uncompress.cpp \
     ../extract_ramdisk/extract_ramdisk.cpp
 
 LOCAL_C_INCLUDES := \

--- a/init/Android.mk
+++ b/init/Android.mk
@@ -56,6 +56,7 @@ LOCAL_STATIC_LIBRARIES := \
     libbase \
     libc \
     libelf \
+    liblzma \
     libz
 
 LOCAL_CLANG := true


### PR DESCRIPTION
It seems you are not using this init anymore. 
However, for some old devices like shinano, we still need it. 

This PR (many thanks to @Diewi for all the work!) add LZMA ramdisk deflate functions. This allow recovery being build with LZMA compression and still booted through extract_elf_ramdisk. 
The split uncompress.cpp file was designed to easily implement other compression methods. 

Thanks for reading. 